### PR TITLE
Refactor fromEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beardedtim/lazy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "index.js",
   "description": "A utility belt for async iterables",
   "keywords": [

--- a/src/operators.js
+++ b/src/operators.js
@@ -246,9 +246,7 @@ const fromEvent = curry(
 
       target.on(event, producer.next);
 
-      while (true) {
-        yield* producer;
-      }
+      yield* producer;
     })
 );
 


### PR DESCRIPTION
Because we can yield* generators and a Producer is a generator,
we do not need to while over the promise generations inside of
fromEvent. We can simply say "yield* producer"